### PR TITLE
CVE-2020-11710 Lab

### DIFF
--- a/http/cves/2020/CVE-2020-11710/README.md
+++ b/http/cves/2020/CVE-2020-11710/README.md
@@ -1,4 +1,4 @@
-# CVE-2020-11710: Kong Admin <=2.03 - Admin API Access
+# CVE-2020-11710 : Kong Admin <=2.03 - Admin API Access
 
 ## Description:
 Kong Admin through 2.0.3 contains an issue via docker-kong which makes the admin API port accessible on interfaces other than 127.0.0.1.
@@ -18,12 +18,58 @@ Kong Admin through 2.0.3 contains an issue via docker-kong which makes the admin
 docker compose up -d
 ```
 
-A specific version of Kong is not required, as this CVE is related to a misconfiguration where the Kong Gateway is configured to be internet facing. You should configure `admin_listen` to be `127.0.0.1:8001`.
+- A specific version of Kong is not required, as this CVE is related to a misconfiguration where the Kong Gateway is configured to be internet facing. You should configure `admin_listen` to be `127.0.0.1:8001`.
+
+## Exploitation Steps
+
+- Visit: http://localhost:8001
+
+- If accessible, this confirms that the Admin API is exposed.
+
+![image](https://github.com/user-attachments/assets/26915d68-cdfe-490d-b5d4-1c232cf10f12)
+
+## Steps to Write Nuclei Template
+
+**HTTP Request Section**
+
+```
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/admin/"
+```
+
+- This sends a GET request to both `/` and `/admin/` to check for possible admin exposure.
+
+**Matchers Section**
+
+```
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Welcome to kong'
+          - 'configuration'
+          - 'kong_env'
+        condition: and
+
+      - type: status
+        status:
+          - 200
+```
+
+- `type: word & condition:` and ensures all the expected content is present in the body.
+
+- `type: status` ensures that the server responded with a successful `200 OK` status.
 
 ## Nuclei Template URL : [CVE-2020-11710](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2020/CVE-2020-11710.yaml)
 
 ## Nuclei Command :
 
 ```bash
-nuclei -t CVE-2020-11710.yaml -u http://172.30.0.2:8001 -vv
+nuclei -u http://localhost:8001 -id CVE-2020-11710 -vv
 ```
+
+![image](https://github.com/user-attachments/assets/2df46925-4145-4dfe-bb3e-4606df73593e)

--- a/http/cves/2020/CVE-2020-11710/README.md
+++ b/http/cves/2020/CVE-2020-11710/README.md
@@ -1,0 +1,29 @@
+# CVE-2020-11710: Kong Admin <=2.03 - Admin API Access
+
+## Description:
+Kong Admin through 2.0.3 contains an issue via docker-kong which makes the admin API port accessible on interfaces other than 127.0.0.1.
+
+## Reference:
+- https://nvd.nist.gov/vuln/detail/CVE-2020-11710
+- https://github.com/Kong/kong
+- https://github.com/Kong/docs.konghq.com/commit/d693827c32144943a2f45abc017c1321b33ff611
+- https://github.com/Kong/docker-kong/commit/dfa095cadf7e8309155be51982d8720daf32e31c
+- https://github.com/Kong/docs.konghq.com/commit/e99cf875d875dd84fdb751079ac37882c9972949
+
+## Vulnerable Setup
+
+- Execute the following commands to start a Kong Gateway in DB-less mode:
+
+```
+docker compose up -d
+```
+
+A specific version of Kong is not required, as this CVE is related to a misconfiguration where the Kong Gateway is configured to be internet facing. You should configure `admin_listen` to be `127.0.0.1:8001`.
+
+## Nuclei Template URL : [CVE-2020-11710](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2020/CVE-2020-11710.yaml)
+
+## Nuclei Command :
+
+```bash
+nuclei -t CVE-2020-11710.yaml -u http://172.30.0.2:8001 -vv
+```

--- a/http/cves/2020/CVE-2020-11710/docker-compose.yml
+++ b/http/cves/2020/CVE-2020-11710/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  kong:
+    image: kong/kong-gateway
+    container_name: kong
+    environment:
+      - KONG_DATABASE=off
+      - KONG_PROXY_ACCESS_LOG=/dev/stdout
+      - KONG_ADMIN_ACCESS_LOG=/dev/stdout
+      - KONG_PROXY_ERROR_LOG=/dev/stderr
+      - KONG_ADMIN_ERROR_LOG=/dev/stderr
+      - KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl
+    ports:
+      - "8000:8000"
+      - "8443:8443"
+      - "8001:8001"
+      - "8444:8444"
+    restart: unless-stopped


### PR DESCRIPTION
This is a simple lab to create a kong gateway server.
The CVE is simply a mis-configuration with the admin port running on `0.0.0.0:8000` so the lab is just running the command here: https://hub.docker.com/r/kong/kong-gateway