### PR TITLE
Exposed MCP SSE Server

### DIFF
--- a/http/exposures/apis/exposed-mcp-sse-server/Dockerfile
+++ b/http/exposures/apis/exposed-mcp-sse-server/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY . /app
+
+# Install dependencies if you have a requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+CMD ["python", "main.py"]

--- a/http/exposures/apis/exposed-mcp-sse-server/README.md
+++ b/http/exposures/apis/exposed-mcp-sse-server/README.md
@@ -1,0 +1,98 @@
+# Exposed MCP SSE Server
+
+## Description:
+Detects exposed Model Context Protocol (MCP) servers through the SSE API. MCP servers often provide administrative access to AI tools, LLM systems, or other automation infrastructure. Exposed MCP interfaces can lead to unauthorized access, information disclosure, and potential system compromise. This template detects a SSE server event stream and returns the messages endpoint which can be used to POST JSON-RPC 2.0 requests.
+
+## Reference:
+- https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse
+
+## Vulnerable Setup
+
+- Execute the following commands to start the MCP SSE server:
+
+```bash
+docker compose up --build -d
+```
+
+- After the server is started, you can send a GET request to the `/sse` endpoint this will start a Server-Side Event stream. And the first event will be a `/messages` endpoint and sessionid where the MCP JSON can be sent to.
+
+## Exploitation Steps
+
+- Send a HTTP GET request to the `/sse` endpoint:
+
+```bash
+curl http://localhost:8081/sse
+```
+
+- The response will send a messages event, such as:
+
+```bash
+event: endpoint
+data: /messages/?session_id=512b026054d04af78c834cb9a5af4e97
+```
+
+- As it is an event stream you will receive the JSON-RPC responses here from any messages POST'ed to the `/messages/?session_id=512b026054d04af78c834cb9a5af4e97` endpoint.
+
+## Steps to Write Nuclei Template
+
+**HTTP Request Section**
+
+```yaml
+- method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/sse"
+```
+
+- The MCP specification does not define what the endpoint will be but it may be under the root or `/sse`
+
+```yaml
+    max-size: 100
+```
+
+- `max-size` is required as the response is streamed, otherwise nuclei will timeout
+
+**Matchers Section**
+
+```yaml
+    stop-at-first-match: true
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200 && contains(content_type, 'text/event-stream')"
+          - "status_code == 406 && contains(content_type, 'application/json')"
+        condition: or
+
+      - type: dsl
+        dsl:
+          - "contains(body, 'event: endpoint')"
+          - "contains(body, 'Not Acceptable: Client must accept text/event-stream')"
+        condition: or
+```
+
+- `stop-at-first-match: true` is used to stop making aditional request if the matchers find a hit.
+
+- `type: dsl` matches a 200 status code and a `text/event-stream` *or* a 406 status code and a `application/json` response
+
+- `type: dsl` matches the first event as defined in the spec as an endpoint event *or* Not Acceptable
+
+**Extractors Section**
+
+```yaml
+    extractors:
+      - type: regex
+        name: message_endpoint
+        regex:
+          - 'data: ([/?_=a-zA-Z0-9-]+)'
+```
+
+- `type: regex` to match the data of the event which will be the messages endpoint with a session_id.
+
+## Nuclei Template URL : [exposed-mcp-sse-server](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/exposures/apis/exposed-mcp-sse-server.yaml)
+
+## Nuclei Command :
+
+```bash
+nuclei -id exposed-mcp-sse-server -u http://localhost:8080 -vv
+```

--- a/http/exposures/apis/exposed-mcp-sse-server/docker-compose.yml
+++ b/http/exposures/apis/exposed-mcp-sse-server/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+
+services:
+  sse:
+    build: .
+    container_name: app
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./:/app
+    restart: unless-stopped

--- a/http/exposures/apis/exposed-mcp-sse-server/main.py
+++ b/http/exposures/apis/exposed-mcp-sse-server/main.py
@@ -1,0 +1,59 @@
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from pydantic import AnyUrl, FileUrl
+
+from mcp.server.sse import SseServerTransport
+from starlette.applications import Starlette
+from starlette.responses import Response
+from starlette.routing import Mount, Route
+
+SAMPLE_RESOURCES = {
+    "greeting": "Hello! This is a sample text resource.",
+    "help": "This server provides a few sample text resources for testing.",
+    "about": "This is the simple-resource MCP server implementation.",
+}
+
+app = Server("mcp-sse-server")
+
+@app.list_resources()
+async def list_resources() -> list[types.Resource]:
+    return [
+        types.Resource(
+            uri=FileUrl(f"file:///{name}.txt"),
+            name=name,
+            description=f"A sample text resource named {name}",
+            mimeType="text/plain",
+        )
+        for name in SAMPLE_RESOURCES.keys()
+    ]
+
+@app.read_resource()
+async def read_resource(uri: AnyUrl) -> str | bytes:
+    if uri.path is None:
+        raise ValueError(f"Invalid resource path: {uri}")
+    name = uri.path.replace(".txt", "").lstrip("/")
+    if name not in SAMPLE_RESOURCES:
+        raise ValueError(f"Unknown resource: {uri}")
+    return SAMPLE_RESOURCES[name]
+
+sse = SseServerTransport("/messages/")
+
+async def handle_sse(request):
+    async with sse.connect_sse(
+        request.scope, request.receive, request._send
+    ) as streams:
+        await app.run(
+            streams[0], streams[1], app.create_initialization_options()
+        )
+    return Response()
+
+starlette_app = Starlette(
+    debug=True,
+    routes=[
+        Route("/sse", endpoint=handle_sse, methods=["GET"]),
+        Mount("/messages/", app=sse.handle_post_message),
+    ],
+)
+
+import uvicorn
+uvicorn.run(starlette_app, host="0.0.0.0", port=8080)

--- a/http/exposures/apis/exposed-mcp-sse-server/requirements.txt
+++ b/http/exposures/apis/exposed-mcp-sse-server/requirements.txt
@@ -1,0 +1,4 @@
+uvicorn
+mcp
+starlette
+pydantic


### PR DESCRIPTION
This lab deploys a MCP HTTP with SSE server which will be detected by [exposed-mcp-sse-server](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/exposures/apis/exposed-mcp-sse-server.yaml)

I have used the MCP server example code from [here](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/servers/simple-resource/mcp_simple_resource/server.py)

<img width="839" alt="image" src="https://github.com/user-attachments/assets/eace971f-9eeb-4e5c-9d14-cd735925dab8" />
